### PR TITLE
Change slack inviter link

### DIFF
--- a/slack/index.html
+++ b/slack/index.html
@@ -20,7 +20,7 @@ title: C++ Language Slack Workspace
     <p class='text-xxs slack-paragraph'>Choose one of the following to get started:</p>
         <ul>
       <li class='slack-link'>
-        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-v5y56qau-cQlsVko720IGu~YgUenIBQ" id="reglink" target="_new">I need an invitation to the C++ Slack workspace.</a>
+        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-15acmok1h-ZxmQgn06jCcw8ajanVa4Rg" id="reglink" target="_new">I need an invitation to the C++ Slack workspace.</a>
       </li>
       <li class='slack-link'>
         <a class='text-m link' href="https://cpplang.slack.com">I already have a C++ Slack workspace account.</a>
@@ -105,7 +105,7 @@ title: C++ Language Slack Workspace
         <a class='text-m link' href="https://slack.com/downloads">Slack Application Downloads</a>
       </li>
       <li class='slack-link'>
-        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-v5y56qau-cQlsVko720IGu~YgUenIBQ">Request an Invitation</a>
+        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-15acmok1h-ZxmQgn06jCcw8ajanVa4Rg">Request an Invitation</a>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
Update slack inviter link.  I contacted tech support about getting a longer duration token.   Their reply:  

```
It will automatically expire after those 10,000 sign-ups, or on March 14, 2023, whichever comes first. In any case, please do reach back out again when that happens if you require further assistance with generating a new link. Hope this helps!

Take care,

Jack
```