### PR TITLE
Slack invite link with 2 year expiration

### DIFF
--- a/slack/index.html
+++ b/slack/index.html
@@ -20,7 +20,7 @@ title: C++ Language Slack Workspace
     <p class='text-xxs slack-paragraph'>Choose one of the following to get started:</p>
         <ul>
       <li class='slack-link'>
-        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-v5y56qau-cQlsVko720IGu~YgUenIBQ" id="reglink" target="_new">I need an invitation to the C++ Slack workspace.</a>
+        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-1snzdn6rp-rOUxF3166oz1_11Tr5H~xg" id="reglink" target="_new">I need an invitation to the C++ Slack workspace.</a>
       </li>
       <li class='slack-link'>
         <a class='text-m link' href="https://cpplang.slack.com">I already have a C++ Slack workspace account.</a>
@@ -105,7 +105,7 @@ title: C++ Language Slack Workspace
         <a class='text-m link' href="https://slack.com/downloads">Slack Application Downloads</a>
       </li>
       <li class='slack-link'>
-        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-v5y56qau-cQlsVko720IGu~YgUenIBQ">Request an Invitation</a>
+        <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-1snzdn6rp-rOUxF3166oz1_11Tr5H~xg">Request an Invitation</a>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
Standard invite links expire after 400 invitations.  This new custom invite link will last 10,000 invitations and 2 years.