### PR TITLE
Update section titles and anchor links on Slack page

### DIFF
--- a/slack/index.html
+++ b/slack/index.html
@@ -7,14 +7,14 @@ title: C++ Language Slack Workspace
 
   <section class="section">
     <div class='section-title'>
-      <h1 class='header text-xl'>Community</h2>
+      <h1 id="#community" class='header text-xl'>Community</h2>
       <h2 class='header-shadow'>Community</h2>
     </div>
   </section>
 
 
   <section class="section">
-    <h2 class='header text-xl section-title'>C++ Slack</h2>
+    <h2 id="#cpp-slack" class='header text-xl section-title'>C++ Slack</h2>
 
     <p class='text-xxs slack-paragraph'> This is a multi-channel Slack workspace environment which gathers users of C++ from around the world into the same place so we can all learn from each other. It is like IRC but with modern clients that support multimedia, notifications, and smart devices.</p>
     <p class='text-xxs slack-paragraph'>Choose one of the following to get started:</p>
@@ -29,26 +29,26 @@ title: C++ Language Slack Workspace
   </section>
 
   <section class="section">
-    <h2 class='header text-xl section-title'>FAQ</h2>
+    <h2 id="#slack-faq" class='header text-xl section-title'>FAQ</h2>
     <ul>
       <li class='slack-list-item'>
-        <h4 class='text-m'>Why do you need my e-mail?</h4>
+        <h4 id="#why-email" class='text-m'><a href="#why-email">Why do you need my e-mail?</a></h4>
         <p class='text-xxs'>Slack is invite based. Your e-mail address is used to register you in the workspace. The invitation tool does not store your address.
         </p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>Who operates this Slack workspace?</h4>
+        <h4 id="who-operates" class='text-m'><a href="#who-operates">Who operates this Slack workspace?</a></h4>
         <p class='text-xxs'>This workspace is paid for and operated in the public interest by The C++ Alliance in accordance with the mission to promote the general welfare of the C++ programming language.</p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>What are the rules?</h4>
+        <h4 id="#rules" class='text-m'><a href="#rules">What are the rules?</a></h4>
         <p class='text-xxs'>Please remain professional in public channels. People from differing cultures and locales all meet here to discuss C++ topics. We ask that you follow the Acceptable Use Policy.</p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>How are the rules enforced?</h4>
+        <h4 id="rules-enforcement" class='text-m'><a href="#rules-enforcement">How are the rules enforced?</a></h4>
         <p class='text-xxs'>Due to the sheer size of the community, it is not practical for admins to police every channel all the time. When you see a user acting poorly, consider letting them know in a nice way. Give a benefit of the doubt generously, as spirited debate is sometimes mistaken for bad behavior.</p>
         <p class='text-xxs'>If diplomacy fails and disruptions persist, mentioning <strong>@mods</strong> in the channel will get the attention of the moderators. Or, you can contact an admin(<a href="https://cpplang.slack.com/account/workspace-settings#admins">list</a>)privately and explain the nature of the problem.</p>
       </li>
@@ -56,11 +56,11 @@ title: C++ Language Slack Workspace
   </section>
 
   <section class="section">
-    <h2 class='header text-xl section-title' id='AUP'>Acceptable Use Policy</h2>
+    <h2 class='header text-xl section-title' id="#acessible-use-policy">Acceptable Use Policy</h2>
     <ol>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>Friendly, professional cooperation</h4>
+        <h4 id="friendly-professional-cooperation" class='text-m'><a href="#friendly-professional-cooperation">Friendly, professional cooperation</a></h4>
         <p class='text-xxs'><em>"First, do no harm."</em></p>
         <p class='text-xxs'>Unlawful statements (including but not limited to credible threats,
         doxxing, cyber-bullying, stalking, or harassment) are prohibited
@@ -68,22 +68,22 @@ title: C++ Language Slack Workspace
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>Safe for work</h4>
+        <h4 id="safe-for-work" class='text-m'><a href="#safe-for-work">Safe for work</a></h4>
         <p class='text-xxs'>Please treat all public channels as Safe For Work (SFW). Don't say anything you wouldn't want a co-worker to see if they pass by your desk.</p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>On-topic discussion</h4>
+        <h4 id="on-topic-discussion" class='text-m'><a href="#on-topic-discussion">On-topic discussion</a></h4>
         <p class='text-xxs'>In every public channel but especially the <strong>#learn</strong> channel which is the most heavily joined, please refrain from off-topic discussion. In public channels, avoid these topics altogether: politics, religion, race, gender, sex.</p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>No excessive self-promotion</h4>
+        <h4 id="no-excessive-self-promotion" class='text-m'><a href="#no-excessive-self-promotion">No excessive self-promotion</a></h4>
         <p class='text-xxs'>A link to your project or news item is of course welcome in the <strong>#plug_worthy</strong> channel. However keep in mind that this community is not intended to be an advertising platform.</p>
       </li>
 
       <li class='slack-list-item'>
-        <h4 class='text-m'>Job offers</h4>
+        <h4 id="job-offers" class='text-m'><a href="#job-offers">Job offers</a></h4>
         <p class='text-xxs'>Job offers are welcomed in the <strong>#job-offers</strong> channel, but please include
         the location, the company, a link to details and keep it in the relevant
         room.</p>
@@ -92,7 +92,7 @@ title: C++ Language Slack Workspace
   </section>
 
   <section class="section">
-    <h2 class='header text-xl section-title'>Links</h2>
+    <h2 id="links" class='header text-xl section-title'>Links</h2>
 
     <ul>
       <li class='slack-link'>
@@ -104,7 +104,7 @@ title: C++ Language Slack Workspace
       <li class='slack-link'>
         <a class='text-m link' href="https://slack.com/downloads">Slack Application Downloads</a>
       </li>
-      <li class='slack-link'>
+      <li id="#who-operates" class='slack-link'>
         <a class='text-m link' href="https://join.slack.com/t/cpplang/shared_invite/zt-1snzdn6rp-rOUxF3166oz1_11Tr5H~xg">Request an Invitation</a>
       </li>
     </ul>


### PR DESCRIPTION
**Adresses issue:** #219 

### Description
Adds fragment ids to the headings on the page