### PR TITLE
Update team titles and index ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           </div>
           <span class='card-text'>
             <h4 class='text-m card-title'>Louis Tatta</h4>
-            <h5 class='text-xs card-subtitle'>Executive Team</h5>
+            <h5 class='text-xs card-subtitle'>CFO/COO</h5>
           </span>
         </a>
       </div>
@@ -199,7 +199,7 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           </div>
           <span class='card-text'>
             <h4 class='text-m card-title'>Sam Darwin</h4>
-            <h5 class='text-xs card-subtitle'>Executive Team</h5>
+            <h5 class='text-xs card-subtitle'>CTO</h5>
           </span>
         </a>
       </div>
@@ -224,7 +224,19 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           </div>
           <span class='card-text'>
             <h4 class='text-m card-title'>Mark Cooper</h4>
-            <h5 class='text-xs card-subtitle'>Consultant</h5>
+            <h5 class='text-xs card-subtitle'>CMO</h5>
+          </span>
+        </a>
+      </div>
+
+      <div class='col-third'>
+        <a class='card' href='{{ site.baseurl }}/people/robert'>
+          <div class='card-img-wrapper'>
+            <img class='card-img' src='{{ site.baseurl }}/images/people/robert.jpg' alt='Robert Beeston'>
+          </div>
+          <span class='card-text'>
+            <h4 class='text-m card-title'>Robert Beeston</h4>
+            <h5 class='text-xs card-subtitle'>Chief of Staff</h5>
           </span>
         </a>
       </div>
@@ -309,18 +321,6 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           <span class='card-text'>
             <h4 class='text-m card-title'>Mohammad Nejati</h4>
             <h5 class='text-xs card-subtitle'>Staff Engineer</h5>
-          </span>
-        </a>
-      </div>
-
-      <div class='col-third'>
-        <a class='card' href='{{ site.baseurl }}/people/robert'>
-          <div class='card-img-wrapper'>
-            <img class='card-img' src='{{ site.baseurl }}/images/people/robert.jpg' alt='Robert Beeston'>
-          </div>
-          <span class='card-text'>
-            <h4 class='text-m card-title'>Robert Beeston</h4>
-            <h5 class='text-xs card-subtitle'>Creative Director</h5>
           </span>
         </a>
       </div>
@@ -428,7 +428,19 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           </span>
         </a>
       </div>
-      
+
+      <div class='col-third'>
+        <a class='card' href='{{ site.baseurl }}/people/krystian'>
+          <div class='card-img-wrapper'>
+            <img class='card-img' src='{{ site.baseurl }}/images/people/krystian.jpg' alt='Krystian Stasiowski'>
+          </div>
+          <span class='card-text'>
+            <h4 class='text-m card-title'>Krystian Stasiowski</h4>
+            <h5 class='text-xs card-subtitle'>Staff Engineer</h5>
+          </span>
+        </a>
+      </div>
+
       </div>
   </section>
 
@@ -617,17 +629,6 @@ description: The C++ Alliance is dedicated to helping the C++ programming langua
           </div>
           <span class='card-text'>
             <h4 class='text-m card-title'>Agustín Bergé</h4>
-            <h5 class='text-xs card-subtitle'>Staff Engineer</h5>
-          </span>
-        </a>
-      </div>
-      <div class='col-third'>
-        <a class='card' href='{{ site.baseurl }}/people/krystian'>
-          <div class='card-img-wrapper'>
-            <img class='card-img' src='{{ site.baseurl }}/images/people/krystian.jpg' alt='Krystian Stasiowski'>
-          </div>
-          <span class='card-text'>
-            <h4 class='text-m card-title'>Krystian Stasiowski</h4>
             <h5 class='text-xs card-subtitle'>Staff Engineer</h5>
           </span>
         </a>

--- a/people/krystian.html
+++ b/people/krystian.html
@@ -1,5 +1,5 @@
 ---
-layout: alumni
+layout: team
 nav-class: dark
 member-name: Krystian Stasiowski
 id: krystian

--- a/people/louis.html
+++ b/people/louis.html
@@ -10,7 +10,7 @@ site: https://louistatta.wordpress.com/
 linkedin: https://www.linkedin.com/in/louis-tatta-83987b2/
 image: /images/people/louis.jpg
 ---
-<p>Louis brings his career expertise spanning finance, development, and management, to his role as Chief Operating Officer. Prior to joining, he was Vice President at J.P. Morgan and worked with the developer behind Bal Harbour Shops, the nation's top-grossing upscale outdoor mall. Louis also held senior roles at Edward Jones and BearShare, where he played a key part in building the company from its inception.</p>
+<p>Louis brings his career expertise spanning finance, development, and management, to his role as CFO/COO. Prior to joining, he was Vice President at J.P. Morgan and worked with the developer behind Bal Harbour Shops, the nation's top-grossing upscale outdoor mall. Louis also held senior roles at Edward Jones and BearShare, where he played a key part in building the company from its inception.</p>
 
 <br>
 

--- a/people/mark.html
+++ b/people/mark.html
@@ -4,7 +4,7 @@ nav-class: dark
 member-name: Mark Cooper
 id: mark
 title: Mark Cooper | The C++ Alliance
-position: Consultant
+position: CMO
 email: mark@cppalliance.org
 linkedin: https://www.linkedin.com/in/marktcooper/
 image: /images/people/mark.jpg

--- a/people/robert.html
+++ b/people/robert.html
@@ -4,7 +4,7 @@ nav-class: dark
 member-name: Robert Beeston
 id: robert
 title: Robert Beeston | The C++ Alliance
-position: Creative Director
+position: Chief of Staff
 email: rob@cppalliance.org
 linkedin: https://www.linkedin.com/in/robbeeston/
 image: /images/people/robert.jpg
@@ -12,7 +12,7 @@ image: /images/people/robert.jpg
 <p>
     Rob has spent over 25 years crafting pixels, writing code, and designing experiences that make users smile.
      With a deep background in front-end development, UI and UX, and visual design, he has worked with companies 
-     of all sizes to turn ideas into intuitive, engaging products. These days, he takes on the role of Product and 
-     Creative Director, blending design thinking, strategy, and just the right amount of creative chaos. 
+     of all sizes to turn ideas into intuitive, engaging products. These days, he takes on the role of Chief of Staff,
+     blending design thinking, strategy, and just the right amount of creative chaos. 
      Also known for his photography skills, stage presence, and love of learning quirky new things. 
 </p>

--- a/people/sam.html
+++ b/people/sam.html
@@ -4,7 +4,7 @@ nav-class: dark
 member-name: Sam Darwin
 id: sam
 title: Sam Darwin | The C++ Alliance
-position: Chief Technology Officer
+position: CTO
 email: sam@cppalliance.org
 site: https://www.samdarwin.com/
 github: https://github.com/sdarwin


### PR DESCRIPTION
## Summary

Refreshes team titles and tidies the executive ordering on the homepage.

**Title updates**
- **Louis Tatta**: "Executive Team" → **CFO/COO** on the index; bio updated from "Chief Operating Officer" to match
- **Sam Darwin**: "Executive Team" → **CTO**; frontmatter shortened from "Chief Technology Officer"
- **Mark Cooper**: Consultant → **CMO**
- **Rob Beeston**: Creative Director → **Chief of Staff** (bio prose updated too)

**Ordering**
- **Rob**'s card moved from the middle of the staff engineer list to sit right after the C-suite (CFO·COO / CMO)
- **Krystian Stasiowski** moved out of the Alumni section back into the active team (layout switched from `alumni` → `team`; card relocated to the end of the staff engineer list)
